### PR TITLE
Install vim-tiny

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Order is important. The last matching pattern has the most precedence.
+
+* @jenkins-infra/docker @jenkins-infra/core

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG mirrorbits_version=v0.5.1
 ENV MIRRORBIT_VERSION=${mirrorbits_version}
 
 RUN apt-get update && \
-  apt-get install -y tar curl && \
+  apt-get install --no-install-recommends -y tar curl ca-certificates && \
   apt-get clean && \
   find /var/lib/apt/lists -type f -delete
 
@@ -39,7 +39,7 @@ ADD https://github.com/krallin/tini/releases/download/${tini_version}/tini /bin/
 RUN chmod +x /bin/tini
 
 RUN apt-get update && \
-  apt-get install -y ftp rsync ca-certificates && \
+  apt-get install --no-install-recommends -y ftp rsync ca-certificates && \
   apt-get clean && \
   find /var/lib/apt/lists -type f -delete
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ADD https://github.com/krallin/tini/releases/download/${tini_version}/tini /bin/
 RUN chmod +x /bin/tini
 
 RUN apt-get update && \
-  apt-get install --no-install-recommends -y ftp rsync ca-certificates && \
+  apt-get install --no-install-recommends -y ftp rsync ca-certificates vim-tiny && \
   apt-get clean && \
   find /var/lib/apt/lists -type f -delete
 


### PR DESCRIPTION
The command `mirrorbits edit <mirror_name>` uses an editor to update configuration. At the moment we don't have any editor inside the docker image. vim-tiny is a tiny editor 