### PR TITLE
Validate the new version of the shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 config.env
 mock/repo/*
+*.tar
+hadolint.json
+Makefile
+cst-result.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ ARG mirrorbits_version=v0.5.1
 
 ENV MIRRORBIT_VERSION=${mirrorbits_version}
 
+## (DL3008)Ignore lint error about apt pinned packages, as we always want the latest version of these tools
+## and the risk of a breaking behavior is evaluated as low
+## (DL3009)Ignore lint error about apt list cleanup as the command "find" is used instead of rm
+# hadolint ignore=DL3008,DL3009
 RUN apt-get update && \
   apt-get install --no-install-recommends -y tar curl ca-certificates && \
   apt-get clean && \
@@ -38,6 +42,10 @@ ADD https://github.com/krallin/tini/releases/download/${tini_version}/tini /bin/
 
 RUN chmod +x /bin/tini
 
+## (DL3008)Ignore lint error about apt pinned packages, as we always want the latest version of these tools
+## and the risk of a breaking behavior is evaluated as low
+## (DL3009)Ignore lint error about apt list cleanup as the command "find" is used instead of rm
+# hadolint ignore=DL3008,DL3009
 RUN apt-get update && \
   apt-get install --no-install-recommends -y ftp rsync ca-certificates vim-tiny && \
   apt-get clean && \
@@ -65,4 +73,3 @@ COPY --from=mirrorbits /mirrorbits/templates /usr/share/mirrorbits/templates
 ENTRYPOINT [ "/bin/tini","--" ]
 
 CMD [ "/usr/bin/mirrorbits","daemon","--config","/etc/mirrorbits/mirrorbits.conf" ]
-

--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ __Why GeoIP requires an account?__
 * [Helm-chart](https://github.com/jenkins-infra/charts/tree/master/charts/mirrorbits)
 * [Jenkinsfile_Shared-Library](https://github.com/jenkins-infra/pipeline-library)
 * [DockerHub](https://hub.docker.com/repository/docker/jenkinsciinfra/mirrorbits)
+
+## Contribute
+
+If you want to contribute, or build/test the Docker Image, please refer to the following documentation about Docker images for the Jenkins Infra project:
+<https://github.com/jenkins-infra/pipeline-library/blob/split_docker_build_and_publish/resources/io/jenkins/infra/docker/README.adoc>.


### PR DESCRIPTION
This PR validates the behavior of the updated shared library used for building (and testing) docker images in a standard way (ref. https://github.com/jenkins-infra/pipeline-library/pull/176).

It introduces the following changes:

- Add to gignore a set of files used by the library or contributor (such as `Makefile`)
- Update README to mention the centralized documentation for contribution through the `Makefile`
- Acknowledge the lint errors DL3008 and DL3009 and ignore within the `Dockerfile` with comments explaining the rationale for each (so the lint part works as expected)