### PR TITLE
feat: build `mirrorbits` with Golang `1.23.0` in the image to get an arm64 binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,6 @@ EXPOSE 8080
 ARG tini_version=v0.19.0
 ARG mirrorbits_version=v0.5.1
 
-LABEL repository="https://github.com/olblak/mirrorbits"
-
 ## (DL3008)Ignore lint error about apt pinned packages, as we always want the latest version of these tools
 ## and the risk of a breaking behavior is evaluated as low
 # hadolint ignore=DL3008
@@ -63,9 +61,11 @@ COPY --from=build /tmp/tools/tini /bin/tini
 COPY --from=build /tmp/tools/mirrorbits/mirrorbits /usr/bin/mirrorbits
 COPY --from=build /tmp/tools/mirrorbits/templates /usr/share/mirrorbits/templates
 
-LABEL io.jenkins-infra.tools="mirrorbits,tini"
-LABEL io.jenkins-infra.tools.mirrorbits.version="${mirrorbits_version}"
-LABEL io.jenkins-infra.tools.tini.version="${tini_version}"
+LABEL \
+  io.jenkins-infra.tools="mirrorbits,tini" \
+  io.jenkins-infra.tools.mirrorbits.version="${mirrorbits_version}" \
+  io.jenkins-infra.tools.tini.version="${tini_version}" \
+  repository="https://github.com/jenkins-infra/docker-mirrorbits"
 
 ENTRYPOINT [ "/bin/tini","--" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim AS mirrorbits
+FROM golang:1.11 AS build
 
 ## (DL3008)Ignore lint error about apt pinned packages, as we always want the latest version of these tools
 ## and the risk of a breaking behavior is evaluated as low
@@ -25,8 +25,8 @@ ARG tini_version=v0.19.0
 RUN curl --silent --show-error --output /tmp/tools/tini --location \
   "https://github.com/krallin/tini/releases/download/${tini_version}/tini-$(dpkg --print-architecture)" && \
   chmod +x /tmp/tools/tini
-
-FROM debian:stable-slim
+  
+FROM debian:stable-slim AS mirrorbits
 
 EXPOSE 8080
 
@@ -59,11 +59,9 @@ USER mirrorbits
 
 COPY config/mirrorbits.conf /etc/mirrorbits/mirrorbits.conf
 
-COPY --from=mirrorbits /tmp/tools/tini /bin/tini
-
-COPY --from=mirrorbits /tmp/tools/mirrorbits/mirrorbits /usr/bin/mirrorbits
-
-COPY --from=mirrorbits /tmp/tools/mirrorbits/templates /usr/share/mirrorbits/templates
+COPY --from=build /tmp/tools/tini /bin/tini
+COPY --from=build /tmp/tools/mirrorbits/mirrorbits /usr/bin/mirrorbits
+COPY --from=build /tmp/tools/mirrorbits/templates /usr/share/mirrorbits/templates
 
 LABEL io.jenkins-infra.tools="mirrorbits,tini"
 LABEL io.jenkins-infra.tools.mirrorbits.version="${mirrorbits_version}"


### PR DESCRIPTION
This PR fixes the arm64 image by building `mirrorbits` binary with the correct architecture as a workaround to the absence of arm64 binary release in https://github.com/etix/mirrorbits.

I wouldn't mind if this PR is refused as it's a bit convoluted, and not without potential flaws.
That would mean give up on `mirrorbits` migration to arm64 (not a big deal).

### Testing done

```console
$ docker build -t mirrorbits-arm --platform linux/arm64 .

$ docker run --platform=linux/arm64 -it mirrorbits-arm uname -a
Linux a1894fa37ce3 5.15.49-linuxkit-pr #1 SMP PREEMPT Thu May 25 07:27:39 UTC 2023 aarch64 GNU/Linux

$ docker run --platform=linux/arm64 -it mirrorbits-arm
 _______ __                        __     __ __
|   |   |__|.----.----.-----.----.|  |--.|__|  |_.-----.
|       |  ||   _|   _|  _  |   _||  _  ||  |   _|__ --|
|__|_|__|__||__| |__| |_____|__|  |_____||__|____|_____|  

2023/10/26 11:33:34.875 UTC open /usr/share/GeoIP/GeoLite2-City.mmdb: no such file or directory
2023/10/26 11:33:34.875 UTC open /usr/share/GeoIP/GeoLite2-ASN.mmdb: no such file or directory
2023/10/26 11:33:34.875 UTC Can't load the GeoIP databases, please set a valid path in the mirrorbits configuration
```

Follow-up of #17

Related to https://github.com/jenkins-infra/helpdesk/issues/3837