### PR TITLE
chore: separate updatecli to its own pipeline

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,7 +1,7 @@
+---
 github:
-  user: "Jenkins Infra Bot (updatecli)"
-  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
-  username: "jenkins-infra-bot"
+  user: "jenkins-infra-updatecli"
+  email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"
   owner: "jenkins-infra"


### PR DESCRIPTION
This PR separates updatecli to its own pipeline  and uses https://github.com/apps/jenkins-infra-updatecli instead of https://github.com/jenkins-infra-bot in updatecli values.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778