### PR TITLE
feat(Dockerfile) symlink mirrorbits downloads logs to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN useradd -M mirrorbits && \
   mkdir /srv/repo && \
   mkdir /run/mirrorbits && \
   mkdir /var/log/mirrorbits && \
+  ln -s /dev/stdout /var/log/mirrorbits/downloads.log && \
   chown mirrorbits -R /usr/share/mirrorbits/ && \
   chown mirrorbits /run/mirrorbits && \
   chown mirrorbits /var/log/mirrorbits && \


### PR DESCRIPTION
In a container world, it is a best practice to send all logs to the container log output and let the container deal with it.

- Logs rotations are easier and it avoids filling data volumes.
- Cloud native integration
- Easier to collect data logs with popular tools