### PR TITLE
chore(updatecli) cleanup manifests

### DIFF
--- a/updatecli/updatecli.d/golang.yaml
+++ b/updatecli/updatecli.d/golang.yaml
@@ -1,0 +1,52 @@
+---
+name: Bump Golang version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestGoVersion:
+    name: Get latest Golang version
+    kind: golang
+
+conditions:
+  checkForDockerImage:
+    name: "Check for a Docker image golang:<versions> used by the Makefile"
+    kind: dockerimage
+    disablesourceinput: true
+    spec:
+      architectures:
+        - amd64
+        - arm64
+      image: golang
+      tag: '{{ source "latestGoVersion" }}'
+
+targets:
+  updateDockerfile:
+    name: Bump Golang version to {{ source `latestGoVersion` }}
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "FROM"
+        matcher: "golang"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump Golang version to {{ source "latestGoVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - golang

--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -1,5 +1,5 @@
 ---
-title: "Bump mirrorbits version"
+name: "Bump mirrorbits version"
 
 scms:
   default:
@@ -16,12 +16,18 @@ scms:
 sources:
   latestRelease:
     name: Get latest mirrorbits release version
-    kind: githubRelease
+    ## Since https://github.com/jenkins-infra/docker-mirrorbits/pull/18, we do not use a fixed mirrorbits tags but
+    ## a custom reference to allow us building for arm64, until we have a new release (https://github.com/etix/mirrorbits/issues/179).
+    # kind: githubrelease
+    # spec:
+    #   owner: "etix"
+    #   repository: "mirrorbits"
+    #   token: "{{ requiredEnv .github.token }}"
+    #   username: "{{ .github.username }}"
+    kind: shell
     spec:
-      owner: "etix"
-      repository: "mirrorbits"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
+      command: echo '955a8b2e1aacea1cae06396a64afbb531ceb36d4'
+
 # no need for condition to check if the docker image is published as we're downloading mirrorbits from github in the Dockerfile
 
 targets:
@@ -33,14 +39,13 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "mirrorbits_version"
-    scmID: default
+    scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
-    scmID: default
-    targets:
-      - updateReleaseInDockerfile
+    kind: github/pullrequest
+    title: Bump mirrorbits version to {{ source `latestRelease` }}
+    scmid: default
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/tini.yaml
+++ b/updatecli/updatecli.d/tini.yaml
@@ -1,4 +1,5 @@
-title: "Bump tini version"
+---
+name: "Bump tini version"
 
 scms:
   default:
@@ -13,16 +14,14 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  latestRelease:
+  lastVersion:
     name: Get Latest tini release version
-    kind: githubRelease
+    kind: githubrelease
     spec:
       owner: "krallin"
       repository: "tini"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-
-# no need for condition to check if the docker image is published as we're downloading tini from github in the Dockerfile
 
 targets:
   updateReleaseInDockerfile:
@@ -33,14 +32,13 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "tini_version"
-    scmID: default
+    scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
-    scmID: default
-    targets:
-      - updateReleaseInDockerfile
+    kind: github/pullrequest
+    title: Bump tini version to {{ source `lastVersion` }}
+    scmid: default
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
- Fix depreciations warnings
- Pin mirrorbits version to the custom git reference we are building
- Track golang version for custom build

Follow up of #18 

Closes #22 (by superseding it)