### PR TITLE
chore(updatecli) track mirrorbits version

### DIFF
--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -16,17 +16,12 @@ scms:
 sources:
   latestRelease:
     name: Get latest mirrorbits release version
-    ## Since https://github.com/jenkins-infra/docker-mirrorbits/pull/18, we do not use a fixed mirrorbits tags but
-    ## a custom reference to allow us building for arm64, until we have a new release (https://github.com/etix/mirrorbits/issues/179).
-    # kind: githubrelease
-    # spec:
-    #   owner: "etix"
-    #   repository: "mirrorbits"
-    #   token: "{{ requiredEnv .github.token }}"
-    #   username: "{{ .github.username }}"
-    kind: shell
+    kind: githubrelease
     spec:
-      command: echo '955a8b2e1aacea1cae06396a64afbb531ceb36d4'
+      owner: "etix"
+      repository: "mirrorbits"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
 
 # no need for condition to check if the docker image is published as we're downloading mirrorbits from github in the Dockerfile
 


### PR DESCRIPTION
As per https://github.com/etix/mirrorbits/issues/179, a new release has been cut after 6 years, so we can resume tracking it