### PR TITLE
Use new _extends syntax for release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-_extends: .github
+_extends: github:jenkins-infra/.github:/.github/release-drafter.yml
 
 name-template: 'next'
 tag-template: 'next'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,10 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
+      # https://github.com/release-drafter/release-drafter/issues/871#issuecomment-3686135188
+      - name: Wait for 15 seconds to ensure GraphQL consistency
+        shell: bash
+        run: sleep 15s
       - name: Release Drafter
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:


### PR DESCRIPTION
## Use new _extends syntax for release drafter

Explicitly load release drafter base config from GitHub

Release drafter v7 no longer accepts .github as a valid extension.

https://github.com/release-drafter/release-drafter/blob/master/docs/configuration-loading.md#fetching-from-a-repo-named-github
says

> The github: prefix is used internally to recognize you want to explicitly fetch from a remote (using octokit) instead of loading a file on the runtime's filesystem.

The release drafter action will continue to fail in this repository until this change is merged.  My apologies that I didn't catch it earlier while sweeping through the repositories for the dependabot v7 upgrade.